### PR TITLE
Make it possible to run specs under Docker again

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ In any environment:
 
 In test:
 * `TEST_CLUSTER_COMMAND` (the command which runs Elasticsearch on your machine)
+* `ELASTICSEARCH_DOCKER_TEST` (if you want to run the tests in Docker)
+* `ELASTICSEARCH_DOCKER_TEST_URL` (Elasticsearch instance url, only when you use Docker)
+* `ELASTICSEARCH_DOCKER_TEST_PORT` (Elasticsearch instance port, only when you use Docker)
 
 ## Collecting Twitter data
 To test that your streaming data collection pipeline is running, by hand:
@@ -127,6 +130,9 @@ development: &default
 ```
 
 - set `ELASTICSEARCH_HOST` and `ELASTICSEARCH_URL` in .env to `elasticsearch:9200`
+- set `ELASTICSEARCH_DOCKER_TEST` in .env to `true`
+- set `ELASTICSEARCH_DOCKER_TEST_URL` in .env to `elasticsearch_test`
+- set `ELASTICSEARCH_DOCKER_TEST_PORT` in .env to `9200`
 - `docker-compose up` and the application will run on http://localhost:3000
 - `docker-compose exec website sh`
 - `rails db:setup`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,27 @@ services:
         hard: 65536
     mem_limit: 4g
 
+  elasticsearch_test:
+    image: elasticsearch:6.5.4
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=0.0.0.0
+      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
+    volumes:
+      - esdata_test:/usr/share/elasticsearch/data
+    ports:
+      - 9201:9200
+      - 9301:9300
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    mem_limit: 4g
+
 volumes:
   postgres:
   esdata:
+  esdata_test:

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -10,4 +10,5 @@ VCR.configure do |config|
   config.filter_sensitive_data('<TWITTER_OAUTH_SECRET>') { ENV['TWITTER_OAUTH_SECRET'] }
   config.configure_rspec_metadata!
   config.allow_http_connections_when_no_cassette = true
+  config.ignore_hosts 'elasticsearch_test'
 end


### PR DESCRIPTION
Hey,

can you take a look, this should work, I just now get 3 specs errors, but probably not related to Docker anymore:

```
  1) Administering CohortCollector when logged in /cohort_collectors/X lets you kick off a streaming twitter data collection run
     Failure/Error: visit cohort_collector_path(cc)
     
     NoMethodError:
       undefined method `strip' for nil:NilClass
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:145:in `chrome_on_linux'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:45:in `chrome_version'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:109:in `release_version'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:31:in `latest_version'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/common.rb:155:in `correct_binary?'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/common.rb:93:in `update'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:177:in `block in <top (required)>'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:133:in `binary_path'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:94:in `initialize'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:41:in `new'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:41:in `chrome'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/driver.rb:299:in `service_url'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/chrome/driver.rb:40:in `initialize'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/driver.rb:46:in `new'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/driver.rb:46:in `for'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver.rb:88:in `for'
     # /usr/local/bundle/gems/capybara-3.20.2/lib/capybara/selenium/driver.rb:48:in `browser'
     # /usr/local/bundle/gems/capybara-3.20.2/lib/capybara/selenium/driver.rb:67:in `visit'
     # /usr/local/bundle/gems/capybara-3.20.2/lib/capybara/session.rb:277:in `visit'
     # /usr/local/bundle/gems/capybara-3.20.2/lib/capybara/dsl.rb:51:in `block (2 levels) in <module:DSL>'
     # ./spec/features/administering_cohort_collector_spec.rb:68:in `block (4 levels) in <top (required)>'

  2) Administering CohortCollector when logged in /cohort_collectors/X lets you create cohorts when creation is permissible
     Failure/Error: visit cohort_collector_path(good_cc)
     
     NoMethodError:
       undefined method `strip' for nil:NilClass
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:145:in `chrome_on_linux'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:45:in `chrome_version'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:109:in `release_version'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:31:in `latest_version'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/common.rb:155:in `correct_binary?'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/common.rb:93:in `update'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:177:in `block in <top (required)>'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:133:in `binary_path'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:94:in `initialize'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:41:in `new'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:41:in `chrome'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/driver.rb:299:in `service_url'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/chrome/driver.rb:40:in `initialize'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/driver.rb:46:in `new'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/driver.rb:46:in `for'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver.rb:88:in `for'
     # /usr/local/bundle/gems/capybara-3.20.2/lib/capybara/selenium/driver.rb:48:in `browser'
     # /usr/local/bundle/gems/capybara-3.20.2/lib/capybara/selenium/driver.rb:67:in `visit'
     # /usr/local/bundle/gems/capybara-3.20.2/lib/capybara/session.rb:277:in `visit'
     # /usr/local/bundle/gems/capybara-3.20.2/lib/capybara/dsl.rb:51:in `block (2 levels) in <module:DSL>'
     # ./spec/features/administering_cohort_collector_spec.rb:108:in `block (4 levels) in <top (required)>'

  3) Administering Cohort #show when logged in as admin lets you initiate data collection
     Failure/Error: visit cohort_path(Cohort.last)
     
     NoMethodError:
       undefined method `strip' for nil:NilClass
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:145:in `chrome_on_linux'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:45:in `chrome_version'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:109:in `release_version'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:31:in `latest_version'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/common.rb:155:in `correct_binary?'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/common.rb:93:in `update'
     # /usr/local/bundle/gems/webdrivers-3.9.4/lib/webdrivers/chromedriver.rb:177:in `block in <top (required)>'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:133:in `binary_path'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:94:in `initialize'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:41:in `new'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/service.rb:41:in `chrome'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/driver.rb:299:in `service_url'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/chrome/driver.rb:40:in `initialize'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/driver.rb:46:in `new'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/common/driver.rb:46:in `for'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver.rb:88:in `for'
     # /usr/local/bundle/gems/capybara-3.20.2/lib/capybara/selenium/driver.rb:48:in `browser'
     # /usr/local/bundle/gems/capybara-3.20.2/lib/capybara/selenium/driver.rb:67:in `visit'
     # /usr/local/bundle/gems/capybara-3.20.2/lib/capybara/session.rb:277:in `visit'
     # /usr/local/bundle/gems/capybara-3.20.2/lib/capybara/dsl.rb:51:in `block (2 levels) in <module:DSL>'
     # ./spec/features/administering_cohort_spec.rb:92:in `block (4 levels) in <top (required)>'
```